### PR TITLE
Version [1.4.2]: Fixed wrong encryption/decryption per environment

### DIFF
--- a/ChustaSoft.Tools.SecureConfig.Net6.TestApi/Program.cs
+++ b/ChustaSoft.Tools.SecureConfig.Net6.TestApi/Program.cs
@@ -24,6 +24,6 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseAuthorization();
 app.MapControllers();
-app.EncryptSettings<AppSettings>();
+app.EncryptSettings<AppSettings>(false);
 
 app.Run();

--- a/ChustaSoft.Tools.SecureConfig.Net6.TestApi/appsettings.Development.json
+++ b/ChustaSoft.Tools.SecureConfig.Net6.TestApi/appsettings.Development.json
@@ -1,11 +1,17 @@
 {
   "AppSettings": {
-    "EncryptedValue": "eG6cwWfN1DLw+mzJOVfqKnT9MuBZ01fnFv+T0TgVfrLe0RX9DguRRAvOD8DE17bv5K+M1pqviPeqXVnsup90xnfq4B4YomJ4rl2kF8p1zcIR0RoU32UG5tykc7HlL47omrWc+4Ynu6VQIFKDoOHrYfwNHJeIhYK0vlZaDMKs8Tw9TY8PFwQgdjmSsIKRrTKy"
+    "ConnectionStrings": {
+      "Conn1": "Connection-1-str-dev",
+      "Conn2": "Connection-2-str-dev"
+    },
+    "TestInt": 5,
+    "TestString": "Test-DEV"
   },
   "Logging": {
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "AllowedHosts": "*"
 }

--- a/ChustaSoft.Tools.SecureConfig.Net6.TestApi/appsettings.json
+++ b/ChustaSoft.Tools.SecureConfig.Net6.TestApi/appsettings.json
@@ -1,6 +1,11 @@
 {
   "AppSettings": {
-    "EncryptedValue": "QdLNsd7fpV2zEDhp7GtYAPcoPZ0oK79XMopHV+Ae2PwXlgQLkmC1oRmz1DoasL2/JQCC5480VewkIF4e8TUR+DWYfcEjY1NNCqHMXeA4OhJdb+BrOctCf6wVWQ2vGRtEg7lM1IRKhpBJz2a6HnyQSemKIFhvOAo0xqmpKNWls1H71fPdHdBrEpimTf6NiQv/"
+    "ConnectionStrings": {
+      "Conn1": "Connection-1-str-prod",
+      "Conn2": "Connection-2-str-prod"
+    },
+    "TestInt": 5,
+    "TestString": "Test-PROD"
   },
   "Logging": {
     "LogLevel": {

--- a/ChustaSoft.Tools.SecureConfig/ChustaSoft.Tools.SecureConfig.csproj
+++ b/ChustaSoft.Tools.SecureConfig/ChustaSoft.Tools.SecureConfig.csproj
@@ -22,7 +22,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ChustaSoft.Common" Version="2.5.0" />
+		<PackageReference Include="ChustaSoft.Common" Version="2.7.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 
@@ -34,8 +34,8 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.22" />
-		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.22" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.24" />
+		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.24" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">

--- a/ChustaSoft.Tools.SecureConfig/ChustaSoft.Tools.SecureConfig.csproj
+++ b/ChustaSoft.Tools.SecureConfig/ChustaSoft.Tools.SecureConfig.csproj
@@ -10,9 +10,9 @@
 		<Company>ChustaSoft</Company>
 		<RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 		<PackageId>ChustaSoft.Tools.SecureConfig</PackageId>
-		<Version>1.4.1</Version>
-		<AssemblyVersion>1.4.1</AssemblyVersion>
-		<FileVersion>1.4.1</FileVersion>
+		<Version>1.4.2</Version>
+		<AssemblyVersion>1.4.2</AssemblyVersion>
+		<FileVersion>1.4.2</FileVersion>
 		<RepositoryUrl>https://github.com/ChustaSoft/SecureConfig.git</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/ChustaSoft/SecureConfig</PackageProjectUrl>
 		<PackageLicenseUrl>https://github.com/ChustaSoft/SecureConfig/blob/main/LICENSE</PackageLicenseUrl>

--- a/ChustaSoft.Tools.SecureConfig/IServiceProviderExtensions.cs
+++ b/ChustaSoft.Tools.SecureConfig/IServiceProviderExtensions.cs
@@ -24,7 +24,7 @@ namespace ChustaSoft.Tools.SecureConfig
                 {
                     var writableOptions = GetWritebleSettings<TSettings>(scope, environmentFile, settingsParamName);
 
-                    if (writableOptions.IsAlreadyEncrypted)
+                    if (writableOptions.IsEncrypted)
                     {
                         var decryptedConfiguration = GetDecryptedConfiguration<TSettings>(scope, writableOptions);
                         writableOptions.Apply(decryptedConfiguration);
@@ -42,7 +42,7 @@ namespace ChustaSoft.Tools.SecureConfig
                 {
                     var writableOptions = GetWritebleSettings<TSettings>(scope, environmentFile, settingsParamName);
 
-                    if (!writableOptions.IsAlreadyEncrypted)
+                    if (!writableOptions.IsEncrypted)
                     {
                         var encryptedConfiguration = GetEncryptedConfiguration(scope, writableOptions);
                         writableOptions.Apply(encryptedConfiguration);

--- a/ChustaSoft.Tools.SecureConfig/SettingsConverter.cs
+++ b/ChustaSoft.Tools.SecureConfig/SettingsConverter.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json.Linq;
+using System.IO;
+
+namespace ChustaSoft.Tools.SecureConfig
+{
+    internal class SettingsConverter
+    {
+        public TSettings Get<TSettings>(string filePath, string sectionName)
+            where TSettings : class
+        {
+            var jsonText = File.ReadAllText(filePath);
+            var jsonObj = JObject.Parse(jsonText);
+            var settingsNode = jsonObj[sectionName];
+            var settingsObj = settingsNode.ToObject<TSettings>();
+
+            return settingsObj;
+        }
+    }
+}

--- a/ChustaSoft.Tools.SecureConfig/WritableSettings.cs
+++ b/ChustaSoft.Tools.SecureConfig/WritableSettings.cs
@@ -14,7 +14,7 @@ namespace ChustaSoft.Tools.SecureConfig
     {
         TSettings DecryptedSettings { get; }
         EncryptedConfiguration EncryptedSettings { get; }
-        bool IsAlreadyEncrypted { get; }
+        bool IsEncrypted { get; }
 
         void Apply(string encryptedValue);
         void Apply(TSettings decryptedObj);
@@ -91,7 +91,7 @@ namespace ChustaSoft.Tools.SecureConfig
             }
         }
 
-        public bool IsAlreadyEncrypted 
+        public bool IsEncrypted 
         { 
             get 
             {

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.4.2] - 2022-04-13
+### Fixed
+- Fixed wrong encryption/decryption values per environment (Critical)
+
+- Internal documentation references changed
 ### [1.4.1] - 2022-02-13
 ### Changed
 - Internal documentation references changed


### PR DESCRIPTION
- Settings was wrongly retrived by configuration manager instead of directly using json files once decryption/encryption was invoked for all environments.